### PR TITLE
Add VSSDK.IDE.Deploy packages for Visual Studio 2010+

### DIFF
--- a/VSSDK.IDE.Deploy.10/VSSDK.IDE.Deploy.10.nuspec
+++ b/VSSDK.IDE.Deploy.10/VSSDK.IDE.Deploy.10.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>VSSDK.IDE.Deploy.10</id>
+    <version>0.0.0</version>
+    <authors>Sam Harwell</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>
+      This package configures a Visual Studio extension to deploy to the Visual Studio 2010 experimental instance when building within Visual Studio.
+    </description>
+    <summary>Deploy to Visual Studio 2010</summary>
+    <tags>vssdk vs2010</tags>
+    <developmentDependency>true</developmentDependency>
+    <dependencies>
+      <!-- Visual Studio 2010 -->
+      <dependency id="VSSDK.IDE.10" version="[10.0.4,11.0.0)"/>
+    </dependencies>
+  </metadata>
+
+  <files>
+    <file src="VSSDK.IDE.Deploy.10.props" target="build"/>
+    <file src="VSSDK.IDE.Deploy.10.targets" target="build"/>
+  </files>
+</package>

--- a/VSSDK.IDE.Deploy.10/VSSDK.IDE.Deploy.10.props
+++ b/VSSDK.IDE.Deploy.10/VSSDK.IDE.Deploy.10.props
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DevEnv10Dir>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\10.0@InstallDir)</DevEnv10Dir>
+  </PropertyGroup>
+</Project>

--- a/VSSDK.IDE.Deploy.10/VSSDK.IDE.Deploy.10.targets
+++ b/VSSDK.IDE.Deploy.10/VSSDK.IDE.Deploy.10.targets
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PrepareForRunDependsOn>
+      $(PrepareForRunDependsOn);
+      DeployToVisualStudio2010
+    </PrepareForRunDependsOn>
+  </PropertyGroup>
+
+  <Target Name="DeployToVisualStudio2010"
+          Condition="'$(DevEnv10Dir)' != '' AND '$(VisualStudioVersion)' != '10.0' AND '$(BuildingInsideVisualStudio)' == 'True'">
+    <Message Importance="high" Text="Deploying extension to Visual Studio 2010..."/>
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="PrepareForRun"
+             Properties="VisualStudioVersion=10.0;BuildingInsideVisualStudio=False;DeployExtension=True;Configuration=$(Configuration);Platform=$(Platform)"/>
+  </Target>
+</Project>

--- a/VSSDK.IDE.Deploy.11/VSSDK.IDE.Deploy.11.nuspec
+++ b/VSSDK.IDE.Deploy.11/VSSDK.IDE.Deploy.11.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>VSSDK.IDE.Deploy.11</id>
+    <version>0.0.0</version>
+    <authors>Sam Harwell</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>
+      This package configures a Visual Studio extension to deploy to the Visual Studio 2012 experimental instance when building within Visual Studio.
+    </description>
+    <summary>Deploy to Visual Studio 2012</summary>
+    <tags>vssdk vs2012</tags>
+    <developmentDependency>true</developmentDependency>
+    <dependencies>
+      <!-- Visual Studio 2012 -->
+      <dependency id="VSSDK.IDE.11" version="[11.0.4,12.0.0)"/>
+    </dependencies>
+  </metadata>
+
+  <files>
+    <file src="VSSDK.IDE.Deploy.11.props" target="build"/>
+    <file src="VSSDK.IDE.Deploy.11.targets" target="build"/>
+  </files>
+</package>

--- a/VSSDK.IDE.Deploy.11/VSSDK.IDE.Deploy.11.props
+++ b/VSSDK.IDE.Deploy.11/VSSDK.IDE.Deploy.11.props
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DevEnv11Dir>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\11.0@InstallDir)</DevEnv11Dir>
+  </PropertyGroup>
+</Project>

--- a/VSSDK.IDE.Deploy.11/VSSDK.IDE.Deploy.11.targets
+++ b/VSSDK.IDE.Deploy.11/VSSDK.IDE.Deploy.11.targets
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PrepareForRunDependsOn>
+      $(PrepareForRunDependsOn);
+      DeployToVisualStudio2012
+    </PrepareForRunDependsOn>
+  </PropertyGroup>
+
+  <Target Name="DeployToVisualStudio2012"
+          Condition="'$(DevEnv11Dir)' != '' AND '$(VisualStudioVersion)' != '11.0' AND '$(BuildingInsideVisualStudio)' == 'True'">
+    <Message Importance="high" Text="Deploying extension to Visual Studio 2012..."/>
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="PrepareForRun"
+             Properties="VisualStudioVersion=11.0;BuildingInsideVisualStudio=False;DeployExtension=True;Configuration=$(Configuration);Platform=$(Platform)"/>
+  </Target>
+</Project>

--- a/VSSDK.IDE.Deploy.12/VSSDK.IDE.Deploy.12.nuspec
+++ b/VSSDK.IDE.Deploy.12/VSSDK.IDE.Deploy.12.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>VSSDK.IDE.Deploy.12</id>
+    <version>0.0.0</version>
+    <authors>Sam Harwell</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>
+      This package configures a Visual Studio extension to deploy to the Visual Studio 2013 experimental instance when building within Visual Studio.
+    </description>
+    <summary>Deploy to Visual Studio 2013</summary>
+    <tags>vssdk vs2013</tags>
+    <developmentDependency>true</developmentDependency>
+    <dependencies>
+      <!-- Visual Studio 2013 -->
+      <dependency id="VSSDK.IDE.12" version="[12.0.4,13.0.0)"/>
+    </dependencies>
+  </metadata>
+
+  <files>
+    <file src="VSSDK.IDE.Deploy.12.props" target="build"/>
+    <file src="VSSDK.IDE.Deploy.12.targets" target="build"/>
+  </files>
+</package>

--- a/VSSDK.IDE.Deploy.12/VSSDK.IDE.Deploy.12.props
+++ b/VSSDK.IDE.Deploy.12/VSSDK.IDE.Deploy.12.props
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DevEnv12Dir>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\12.0@InstallDir)</DevEnv12Dir>
+  </PropertyGroup>
+</Project>

--- a/VSSDK.IDE.Deploy.12/VSSDK.IDE.Deploy.12.targets
+++ b/VSSDK.IDE.Deploy.12/VSSDK.IDE.Deploy.12.targets
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PrepareForRunDependsOn>
+      $(PrepareForRunDependsOn);
+      DeployToVisualStudio2013
+    </PrepareForRunDependsOn>
+  </PropertyGroup>
+
+  <Target Name="DeployToVisualStudio2013"
+          Condition="'$(DevEnv12Dir)' != '' AND '$(VisualStudioVersion)' != '12.0' AND '$(BuildingInsideVisualStudio)' == 'True'">
+    <Message Importance="high" Text="Deploying extension to Visual Studio 2013..."/>
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="PrepareForRun"
+             Properties="VisualStudioVersion=12.0;BuildingInsideVisualStudio=False;DeployExtension=True;Configuration=$(Configuration);Platform=$(Platform)"/>
+  </Target>
+</Project>

--- a/VSSDK.IDE.Deploy.14/VSSDK.IDE.Deploy.14.nuspec
+++ b/VSSDK.IDE.Deploy.14/VSSDK.IDE.Deploy.14.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>VSSDK.IDE.Deploy.14</id>
+    <version>0.0.0</version>
+    <authors>Sam Harwell</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>
+      This package configures a Visual Studio extension to deploy to the Visual Studio 2015 experimental instance when building within Visual Studio.
+    </description>
+    <summary>Deploy to Visual Studio 2015</summary>
+    <tags>vssdk vs2015</tags>
+    <developmentDependency>true</developmentDependency>
+    <dependencies>
+      <!-- Visual Studio 2015 -->
+      <dependency id="VSSDK.IDE.14" version="[14.0.4-preview,15.0.0)"/>
+    </dependencies>
+  </metadata>
+
+  <files>
+    <file src="VSSDK.IDE.Deploy.14.props" target="build"/>
+    <file src="VSSDK.IDE.Deploy.14.targets" target="build"/>
+  </files>
+</package>

--- a/VSSDK.IDE.Deploy.14/VSSDK.IDE.Deploy.14.props
+++ b/VSSDK.IDE.Deploy.14/VSSDK.IDE.Deploy.14.props
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DevEnv14Dir>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\14.0@InstallDir)</DevEnv14Dir>
+  </PropertyGroup>
+</Project>

--- a/VSSDK.IDE.Deploy.14/VSSDK.IDE.Deploy.14.targets
+++ b/VSSDK.IDE.Deploy.14/VSSDK.IDE.Deploy.14.targets
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PrepareForRunDependsOn>
+      $(PrepareForRunDependsOn);
+      DeployToVisualStudio2015
+    </PrepareForRunDependsOn>
+  </PropertyGroup>
+
+  <Target Name="DeployToVisualStudio2015"
+          Condition="'$(DevEnv14Dir)' != '' AND '$(VisualStudioVersion)' != '14.0' AND '$(BuildingInsideVisualStudio)' == 'True'">
+    <Message Importance="high" Text="Deploying extension to Visual Studio 2015..."/>
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="PrepareForRun"
+             Properties="VisualStudioVersion=14.0;BuildingInsideVisualStudio=False;DeployExtension=True;Configuration=$(Configuration);Platform=$(Platform)"/>
+  </Target>
+</Project>

--- a/build-2010.ps1
+++ b/build-2010.ps1
@@ -12,6 +12,7 @@ $packages = @(
 	# Visual Studio 2010 Metadata Package
 	'VSSDK.IDE.10'
 	'VSSDK.IDE.10Only'
+	'VSSDK.IDE.Deploy.10'
 
 	# Immutable COM-interop packages
 	'VSSDK.Debugger.Interop.10'

--- a/build-2012.ps1
+++ b/build-2012.ps1
@@ -12,6 +12,7 @@ $packages = @(
 	# Visual Studio 2012 Metadata Package
 	'VSSDK.IDE.11'
 	'VSSDK.IDE.11Only'
+	'VSSDK.IDE.Deploy.11'
 
 	# Immutable COM-interop packages
 	'VSSDK.Debugger.Interop.11'

--- a/build-2013.ps1
+++ b/build-2013.ps1
@@ -12,6 +12,7 @@ $packages = @(
 	# Visual Studio 2013 Metadata Package
 	'VSSDK.IDE.12'
 	'VSSDK.IDE.12Only'
+	'VSSDK.IDE.Deploy.12'
 
 	# Immutable COM-interop packages
 	'VSSDK.Debugger.Interop.12'

--- a/build-2015.ps1
+++ b/build-2015.ps1
@@ -12,6 +12,7 @@ $packages = @(
 	# Visual Studio 2015 Metadata Package
 	'VSSDK.IDE.14'
 	'VSSDK.IDE.14Only'
+	'VSSDK.IDE.Deploy.14'
 
 	# Immutable COM-interop packages
 	'VSSDK.Debugger.Interop.14'


### PR DESCRIPTION
These packages enable a build within Visual Studio 2010-2015 to deploy an extension to any combination of Visual Studio 2010-2015. For example, if the **VSSDK.IDE.Deploy.10** package is installed in a project, then any build within Visual Studio 2010, 2012, 2013, or 2015 will automatically deploy the package to the Visual Studio 2010 experimental instance if (and only if) Visual Studio 2010 is installed.

These packages allow users to *easily* debug an extension running in Visual Studio 2010 from another version of Visual Studio, such as Visual Studio 2013.